### PR TITLE
Fix 'Npm build' step in Actions workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Npm install
       run: npm ci
     - name: Npm build
-      run: npm build 
+      run: npm run build --if-present 


### PR DESCRIPTION
# Summary

The current "Npm build" step in this Actions workflow does not run properly - see https://github.com/cla-assistant/github-action/runs/444688399?check_suite_focus=true#step:5:4.

To fix this, I am proposing running it like the Node.js starter workflow - https://github.com/actions/starter-workflows/blob/e5a3a0e11268f84ad0ff6569a47e197cc8e1f758/ci/node.js.yml#L21

Result: https://github.com/cla-assistant/github-action/pull/6/checks?check_run_id=445379728#step:5:6