### PR TITLE
Add support for custom commit messages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,19 @@ inputs:
     description: "GitHub Actions will add empty commit whenever the user signs the CLA (optional)"
     default: true
   allowlist:
-    description: "users in the allow list don't have to sign the CLA document"
+    description: "Users in the allow list don't have to sign the CLA document"
   path-to-cla-document:
     description: "Fully qualified web link to cla document Example: https://github.com/cla-assistant/github-action/blob/master/SAPCLA.md"
+  signed-comment-message:
+    description: "Commit message when a new contributor signs the CLA in a PR"
+  request-comment-message:
+    description: "Introductory message to ask new contributors to sign"
+  signed-empty-commit-message:
+    description: "Commit message when a new contributor signs the CLA (empty)"
+  create-file-commit-message:
+    description: "Commit message when a new file is created"
+  all-signed-comment-message:
+    description: "Commit message when everyone has signed, defaults to **CLA Assistant Lite** All Contributors have signed the CLA."
 runs:
   using: "node12"
   main: "lib/main.js"

--- a/src/addEmptyCommit.ts
+++ b/src/addEmptyCommit.ts
@@ -11,7 +11,7 @@ export async function addEmptyCommit() {
         //Do empty commit only when the contributor signs the CLA with the PR comment 
         if (context.payload.comment.body === 'I have read the CLA Document and I hereby sign the CLA') {
             try {
-                const commitMessage = core.getInput('signed-commit-message')
+                const commitMessage = core.getInput('signed-empty-commit-message')
                 const message = commitMessage ?
                       commitMessage.replace('$contributorName', contributorName) :
                       ` @${contributorName} has signed the CLA `

--- a/src/addEmptyCommit.ts
+++ b/src/addEmptyCommit.ts
@@ -11,7 +11,10 @@ export async function addEmptyCommit() {
         //Do empty commit only when the contributor signs the CLA with the PR comment 
         if (context.payload.comment.body === 'I have read the CLA Document and I hereby sign the CLA') {
             try {
-                const message = ` @${contributorName} has signed the CLA `
+                const commitMessage = core.getInput('signed-commit-message')
+                const message = commitMessage ?
+                      commitMessage.replace('$contributorName', contributorName) :
+                      ` @${contributorName} has signed the CLA `
                 const pullRequestResponse = await octokit.pulls.get({
                     owner: context.repo.owner,
                     repo: context.repo.repo,

--- a/src/checkcla.ts
+++ b/src/checkcla.ts
@@ -126,12 +126,15 @@ function prepareCommiterMap(committers: CommittersDetails[], clas): CommitterMap
 }
 //TODO: refactor the commit message when a project admin does recheck PR
 async function updateFile(pathToClaSignatures, sha, contentBinary, branch, pullRequestNo) {
+  const commitMessage = core.getInput('signed-commit-message')
   await octokit.repos.createOrUpdateFile({
     owner: context.repo.owner,
     repo: context.repo.repo,
     path: pathToClaSignatures,
     sha: sha,
-    message: `@${context.actor} has signed the CLA from Pull Request ${pullRequestNo}`,
+    message: commitMessage ?
+      commitMessage.replace('$contributorName', context.actor).replace('$pullRequestNo', pullRequestNo) :
+      `@${context.actor} has signed the CLA from Pull Request ${pullRequestNo}`,
     content: contentBinary,
     branch: branch
   })

--- a/src/checkcla.ts
+++ b/src/checkcla.ts
@@ -139,11 +139,13 @@ async function updateFile(pathToClaSignatures, sha, contentBinary, branch, pullR
 
 function createFile(pathToClaSignatures, contentBinary, branch): Promise<object> {
   /* TODO: add dynamic message content  */
+  const commitMessage = core.getInput('create-file-commit-message')
   return octokit.repos.createOrUpdateFile({
     owner: context.repo.owner,
     repo: context.repo.repo,
     path: pathToClaSignatures,
     message:
+      commitMessage ||
       'Creating file for storing CLA Signatures',
     content: contentBinary,
     branch: branch

--- a/src/pullRequestComment.ts
+++ b/src/pullRequestComment.ts
@@ -23,7 +23,7 @@ function commentContent(signed: boolean, committerMap: CommitterMap): string {
   const pathToCLADocument = core.getInput('path-to-cla-document')
 
   if (signed) {
-    return `**CLA Assistant Lite** All Contributors  have signed the CLA. `
+    return core.getInput('signed-comment-message') || `**CLA Assistant Lite** All Contributors have signed the CLA.`
   }
   let committersCount = 1
   if (committerMap && committerMap.signed && committerMap.notSigned) {
@@ -31,7 +31,8 @@ function commentContent(signed: boolean, committerMap: CommitterMap): string {
       committerMap.signed.length + committerMap.notSigned.length
   }
   let you = committersCount > 1 ? "you all" : "you"
-  let text = `**CLA Assistant Lite:** <br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that ${you} sign our [Contributor License Agreement](${pathToCLADocument}) before we can accept your contribution. You can sign the CLA by just  posting a Pull Request Comment same as the below format.
+  let lineOne = (core.getInput('request-comment-message') || '**CLA Assistant Lite:** <br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Contributor License Agreement]($pathToCLADocument) before we can accept your contribution. You can sign the CLA by just posting a Pull Request Comment same as the below format.').replace('$pathToCLADocument', pathToCLADocument).replace('$you', you)
+  let text = `${lineOne}
   - - -
   ***I have read the CLA Document and I hereby sign the CLA***
   - - - 

--- a/src/pullRequestComment.ts
+++ b/src/pullRequestComment.ts
@@ -23,7 +23,7 @@ function commentContent(signed: boolean, committerMap: CommitterMap): string {
   const pathToCLADocument = core.getInput('path-to-cla-document')
 
   if (signed) {
-    return core.getInput('signed-comment-message') || `**CLA Assistant Lite** All Contributors have signed the CLA.`
+    return core.getInput('all-signed-comment-message') || `**CLA Assistant Lite** All Contributors have signed the CLA.`
   }
   let committersCount = 1
   if (committerMap && committerMap.signed && committerMap.notSigned) {


### PR DESCRIPTION
This PR fixes #32 by adding these options:

- `signed-commit-message` is the commit message when a new contributor signs the CLA in a PR
- `signed-empty-commit-message` is the commit message when a new contributor signs the CLA (empty)
- `create-file-commit-message` is the commit message when a new file is created

**Usage example:**

```yaml
jobs:
  CLAssistant:
    runs-on: ubuntu-latest
    steps:
      - name: "CLA Assistant"
        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
        uses: cla-assistant/github-action@v1.4.2-alpha
        env: 
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with: 
          path-to-signatures: 'signatures/version1/cla.json'
          signed-commit-message: 'chore(cla): $contributorName has signed the CLA in #$pullRequestNo'
          create-file-commit-message: 'chore(cla): Creating file for storing CLA Signatures'
```