### PR TITLE
fix: remove space that breaks markdown formatting for dco option

### DIFF
--- a/src/pullrequest/pullRequestCommentContent.ts
+++ b/src/pullrequest/pullRequestCommentContent.ts
@@ -30,7 +30,7 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Developer Certificate of Origin](${input.getPathToDocument()}) before we can accept your contribution. You can sign the DCO by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you)
     let text = `**DCO Assistant Lite bot:** ${lineOne}
    - - -
-   ***${input.getCustomPrSignComment() || "I have read the DCO Document and I hereby sign the DCO"} ***
+   ${input.getCustomPrSignComment() || "I have read the DCO Document and I hereby sign the DCO"}
    - - -
    `
 
@@ -72,7 +72,7 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Contributor License Agreement](${input.getPathToDocument()}) before we can accept your contribution. You can sign the CLA by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you)
     let text = `**CLA Assistant Lite bot:** ${lineOne}
    - - -
-   ***${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}***
+   ${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}
    - - -
    `
 

--- a/src/pullrequest/pullRequestCommentContent.ts
+++ b/src/pullrequest/pullRequestCommentContent.ts
@@ -30,7 +30,7 @@ function dco(signed: boolean, committerMap: CommitterMap): string {
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Developer Certificate of Origin](${input.getPathToDocument()}) before we can accept your contribution. You can sign the DCO by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you)
     let text = `**DCO Assistant Lite bot:** ${lineOne}
    - - -
-   ${input.getCustomPrSignComment() || "I have read the DCO Document and I hereby sign the DCO"}
+   ***${input.getCustomPrSignComment() || "I have read the DCO Document and I hereby sign the DCO"}***
    - - -
    `
 
@@ -72,7 +72,7 @@ function cla(signed: boolean, committerMap: CommitterMap): string {
     let lineOne = (input.getCustomNotSignedPrComment() || `<br/>Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that $you sign our [Contributor License Agreement](${input.getPathToDocument()}) before we can accept your contribution. You can sign the CLA by just posting a Pull Request Comment same as the below format.<br/>`).replace('$you', you)
     let text = `**CLA Assistant Lite bot:** ${lineOne}
    - - -
-   ${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}
+   ***${input.getCustomPrSignComment() || "I have read the CLA Document and I hereby sign the CLA"}***
    - - -
    `
 


### PR DESCRIPTION
This pull request fixes two issues.

1) It's unclear if you're supposed to include the `***` or not surrounding the confirmation text. If you include it, it looks like broken markdown formatting.

2) The DCO option has an extra space between the confirmation text and the ending `***`.

Both are addressed by removing the `***`. Here is a screenshot before the fix to show the as-is:

![image](https://user-images.githubusercontent.com/1691245/110701834-4a458380-81b7-11eb-938f-19bd2a032194.png)
