### PR TITLE
Feature: Add the ability to `exemptRepoOrgMembers`.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   allowlist:
     description: "users in the allow list don't have to sign the CLA document"
     default: ""
+  exemptRepoOrgMembers:
+    description: "if `true`, members of the organization to which the repository belongs are automatically allowlisted"
+    default: false
   remote-repository-name:
     description: "provide the remote repository name where all the signatures should be stored"
   remote-organization-name:

--- a/src/checkAllowList.ts
+++ b/src/checkAllowList.ts
@@ -1,9 +1,8 @@
+import * as core from '@actions/core'
 import { CommittersDetails } from './interfaces'
 
 import * as _ from 'lodash'
 import * as input from './shared/getInputs'
-
-
 
 function isUserNotInAllowList(committer) {
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,15 +1,24 @@
-import { octokit } from './octokit'
+import * as octokit from './octokit'
 import { context } from '@actions/github'
 import { CommittersDetails } from './interfaces'
-
-
+import * as core from '@actions/core'
 
 export default async function getCommitters(): Promise<CommittersDetails[]> {
     try {
+        let client = (octokit.isPersonalAccessTokenPresent()) ? octokit.getPATOctokit() : octokit.octokit
         let committers: CommittersDetails[] = []
-        let filteredCommitters: CommittersDetails[] = []
-        let response: any = await octokit.graphql(`
+        let desiredSignatories: CommittersDetails[] = []
+        let response: any = await client.graphql(`
         query($owner:String! $name:String! $number:Int! $cursor:String!){
+            organization(login: $owner) {
+                membersWithRole(first: 100) {
+                    edges {
+                        node {
+                            login
+                        }
+                    }
+                }
+            }
             repository(owner: $owner, name: $name) {
             pullRequest(number: $number) {
                 commits(first: 100, after: $cursor) {
@@ -24,6 +33,11 @@ export default async function getCommitters(): Promise<CommittersDetails[]> {
                                         id
                                         databaseId
                                         login
+                                        organizations(first: 100) {
+                                            nodes {
+                                                login
+                                            }
+                                        }
                                     }
                                 }
                                 committer {
@@ -32,6 +46,11 @@ export default async function getCommitters(): Promise<CommittersDetails[]> {
                                         id
                                         databaseId
                                         login
+                                        organizations(first: 100) {
+                                            nodes {
+                                                login
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -52,11 +71,15 @@ export default async function getCommitters(): Promise<CommittersDetails[]> {
             cursor: ''
         })
         response.repository.pullRequest.commits.edges.forEach(edge => {
+            core.debug(JSON.stringify(response.organization, undefined, 2))
             const committer = extractUserFromCommit(edge.node.commit)
             let user = {
                 name: committer.login || committer.name,
                 id: committer.databaseId || '',
-                pullRequestNo: context.issue.number
+                pullRequestNo: context.issue.number,
+                orgLogins: committer.organizations.nodes.map(org => {
+                    return org.login
+                })
             }
             if (committers.length === 0 || committers.map((c) => {
                 return c.name
@@ -64,14 +87,33 @@ export default async function getCommitters(): Promise<CommittersDetails[]> {
                 committers.push(user)
             }
         })
-        filteredCommitters = committers.filter((committer) => {
-            return committer.id !== 41898282
-        })
-        return filteredCommitters
+        desiredSignatories = committers.filter((committer) => {
+            if (committer.id === 41898282) { // Filter this one out.
+                return false
+            }
 
+            if (core.getInput('exemptRepoOrgMembers')) {
+                // The `exemptRepoOrgMembers` input determines whether
+                // we automatically "allowlist" the members of the org
+                // owning the repository we are working in. If so, we
+                // can filter those committers here, thus allowing them
+                // to bypass the check informing them they need to sign
+                // the CLA.
+                let members = response.organization.membersWithRole.edges.map(edge => {
+                    return edge.node.login
+                })
+                core.debug("Filtering based on these members:")
+                core.debug(JSON.stringify(members, undefined, 2))
+                core.debug("Current committer name to check for filtering:")
+                return ! members.includes(committer.name) // Negate so `includes()` filters out, not in.
+            }
+
+            return true
+        })
+        core.debug(JSON.stringify(desiredSignatories, undefined, 2))
+        return desiredSignatories
     } catch (e) {
         throw new Error(`graphql call to get the committers details failed: ${e}`)
     }
-
 }
 const extractUserFromCommit = (commit) => commit.author.user || commit.committer.user || commit.author || commit.committer

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,6 +22,7 @@ export interface CommittersDetails {
     comment_id?: number,
     body?: string,
     repoId?: string
+    orgLogins?: string[]
 }
 export interface LabelName {
     current_name: string,


### PR DESCRIPTION
The new `exemptRepoOrgMembers` input to the GitHub Action for this Contributor Assistant automatically "allowlists" members of a repository's GitHub Organization, enabling those GitHub committers to bypass the requirement to sign the organization's CLA document when they are committers on a Pull Request that would otherwise require them to be signatories for their contribution.

This implementation is similar to and may provide guidance for implementing feature request #100, but works for Organizations instead of individual Teams.